### PR TITLE
Resiliency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,11 +30,10 @@ dependencies {
 	compile('org.springframework.boot:spring-boot-starter-actuator')
 	compile('org.springframework.cloud:spring-cloud-starter-eureka')
 	compile('org.springframework.cloud:spring-cloud-starter-zuul')
-
-	compile('org.springframework.cloud:spring-cloud-netflix-turbine')
-
 	compile('org.springframework.cloud:spring-cloud-starter-hystrix-dashboard')
-
+        compile('org.springframework.cloud:spring-cloud-starter-stream-rabbit')
+        compile('org.springframework.cloud:spring-cloud-starter-turbine-stream')
+        compile('org.springframework.boot:spring-boot-starter-web')
 	testCompile('org.springframework.boot:spring-boot-starter-test')
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,15 +33,23 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-zuul</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-netflix-turbine</artifactId>
-		</dependency>
+                <dependency>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-starter-turbine-stream</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
+                </dependency>
+
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-hystrix-dashboard</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+			<version>Brixton.SR4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/runlocal.sh
+++ b/runlocal.sh
@@ -1,0 +1,2 @@
+echo "Starting turbine ........... streaming on port 8989"
+docker run --name netflix-turbine -p 8989:8989 -p 8990:8990 --env-file ~/ibm-cloud-architecture/refarch-cloudnative-container-utils/env/env-eureka-only-local -d netflix-turbine:latest

--- a/src/main/java/com/ibm/microservices/refapp/turbine/TurbineServerApplication.java
+++ b/src/main/java/com/ibm/microservices/refapp/turbine/TurbineServerApplication.java
@@ -3,13 +3,12 @@ package com.ibm.microservices.refapp.turbine;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
-import org.springframework.cloud.netflix.turbine.EnableTurbine;
-import org.springframework.cloud.netflix.hystrix.dashboard.EnableHystrixDashboard;
+import org.springframework.cloud.netflix.turbine.stream.EnableTurbineStream;
 
 @SpringBootApplication
 @EnableDiscoveryClient
-@EnableTurbine
-@EnableHystrixDashboard
+@EnableTurbineStream
+
 public class TurbineServerApplication {
 
     public static void main(String[] args) {


### PR DESCRIPTION
Changes to add decoration for Rabbit Stream and also remove Hystrix from this component as I had issues trying to connect with Turbine when it was both.   All the details of starting the solution are with the README.md in the new Hystrix repo at:  https://github.com/dbellagio/refarch-cloudnative-netflix-hystrix